### PR TITLE
Fixes LogicException not being thrown

### DIFF
--- a/src/Routing/Filter/ThrottleFilter.php
+++ b/src/Routing/Filter/ThrottleFilter.php
@@ -9,8 +9,14 @@ use Cake\Routing\DispatcherFilter;
 
 class ThrottleFilter extends DispatcherFilter
 {
+
     public static $cacheConfig = 'throttle';
 
+    /**
+     * Class constructor.
+     *
+     * @param array $config Configuration options
+     */
     public function __construct($config = [])
     {
         $config += [
@@ -29,11 +35,23 @@ class ThrottleFilter extends DispatcherFilter
         $this->_initCache();
     }
 
+    /**
+     * Class constructor.
+     *
+     * @param Cake\Network\Request $request Request instance
+     * @return Cake\Network\Request
+     */
     public function when(Request $request)
     {
         return $this->config('rate') > $this->_touch($request);
     }
 
+    /**
+     * beforeDispatch.
+     *
+     * @param Cake\Event\Event $event Event instance
+     * @return Cake\Network\Response
+     */
     public function beforeDispatch(Event $event)
     {
         $event->stopPropagation();
@@ -43,6 +61,11 @@ class ThrottleFilter extends DispatcherFilter
         return $response;
     }
 
+    /**
+     * Initializes cache.
+     *
+     * @return void
+     */
     protected function _initCache()
     {
         if (!Cache::config(static::$cacheConfig)) {
@@ -53,13 +76,18 @@ class ThrottleFilter extends DispatcherFilter
         }
     }
 
+    /**
+     * Atomically updates cache using default CakePHP increment offset 1.
+     *
+     * @param Cake\Network\Request $request Request instance
+     * @return Cake\Cache\Cache
+     */
     protected function _touch(Request $request)
     {
         $key = $this->config('identifier');
         if (is_callable($key)) {
             $key = $key($request);
         }
-
-        return Cache::increment($key, static::$cacheConfig);
+        return Cache::increment($key, 1, static::$cacheConfig);
     }
 }

--- a/tests/TestCase/Routing/Filter/ThrottleFilterTest.php
+++ b/tests/TestCase/Routing/Filter/ThrottleFilterTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Muffin\Throttle\Test\TestCase\Routing\Filter;
 
+use Cake\Cache\Cache;
 use Cake\Event\Event;
+use Cake\Network\Request;
 use Cake\TestSuite\TestCase;
 use Muffin\Throttle\Routing\Filter\ThrottleFilter;
 
@@ -29,4 +31,22 @@ class ThrottleFilterTest extends TestCase
         $this->assertEquals(429, $result->statusCode());
     }
 
+    /**
+     * Using the File Storage cache engine should throw a LogicException.
+     *
+     * @expectedException \LogicException
+     */
+    public function testFileCacheException()
+    {
+        Cache::config('file', [
+            'className' => 'Cake\Cache\Engine\FileEngine',
+            'prefix' => 'throttle_'
+        ]);
+
+        $object = new ThrottleFilter();
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod('_touch');
+        $method->setAccessible(true);
+        $method->invokeArgs($object, [new Request()]);
+    }
 }


### PR DESCRIPTION
Fixes LogicException not being thrown when using File cache (caused by incompatible call to https://github.com/cakephp/cakephp/blob/master/src/Cache/Engine/FileEngine.php#L357 ?)
