### PR TITLE
Moves header logic to afterDispatch to support exceptions etc

### DIFF
--- a/src/Routing/Filter/ThrottleFilter.php
+++ b/src/Routing/Filter/ThrottleFilter.php
@@ -86,8 +86,19 @@ class ThrottleFilter extends DispatcherFilter
         $response = new Response(['body' => $this->config('message')]);
         $response->httpCodes([429 => 'Too Many Requests']);
         $response->statusCode(429);
-        $this->_setHeaders($response);
         return $response;
+    }
+
+    /**
+     * afterDispatch.
+     *
+     * @param Cake\Event\Event $event Event instance
+     * @return Cake\Network\Response Response instance
+     */
+    public function afterDispatch(Event $event)
+    {
+        $this->_setHeaders($event->data['response']);
+        return $event->data['response'];
     }
 
     /**

--- a/tests/TestCase/Routing/Filter/ThrottleFilterTest.php
+++ b/tests/TestCase/Routing/Filter/ThrottleFilterTest.php
@@ -65,6 +65,31 @@ class ThrottleFilterTest extends TestCase
     }
 
     /**
+     * Test afterDispatch
+     */
+    public function testAfterDispatch()
+    {
+        Cache::drop('throttle');
+        Cache::config('throttle', [
+            'className' => 'Cake\Cache\Engine\ApcEngine',
+            'prefix' => 'throttle_'
+        ]);
+
+        $filter = new ThrottleFilter([
+            'limit' => 1
+        ]);
+        $response = new Response();
+        $request = new Request([
+            'environment' => [
+                'HTTP_CLIENT_IP' => '192.168.1.2'
+            ]
+        ]);
+
+        $event = new Event('Dispatcher.beforeDispatch', $this, compact('request', 'response'));
+        $result = $filter->afterDispatch($event);
+        $this->assertInstanceOf('Cake\Network\Response', $result);
+    }
+    /**
      * Using the File Storage cache engine should throw a LogicException.
      *
      * @expectedException \LogicException


### PR DESCRIPTION
Set headers during `afterDispactch()` to fix missing headers for exceptions. 

Triggered by this conversation https://github.com/FriendsOfCake/crud/issues/276
