### PR TITLE
replace recursively

### DIFF
--- a/src/Middleware/ThrottleMiddleware.php
+++ b/src/Middleware/ThrottleMiddleware.php
@@ -26,7 +26,7 @@ class ThrottleMiddleware
      */
     public function __construct($config = [])
     {
-        $config += $this->_setConfiguration();
+        $config = array_replace_recursive($this->_setConfiguration(), $config);
         $this->setConfig($config);
     }
 

--- a/src/Routing/Filter/ThrottleFilter.php
+++ b/src/Routing/Filter/ThrottleFilter.php
@@ -18,7 +18,7 @@ class ThrottleFilter extends DispatcherFilter
      */
     public function __construct($config = [])
     {
-        $config += $this->_setConfiguration();
+        $config = array_replace_recursive($this->_setConfiguration(), $config);
 
         parent::__construct($config);
     }

--- a/tests/TestCase/Middleware/ThrottleMiddlewareTest.php
+++ b/tests/TestCase/Middleware/ThrottleMiddlewareTest.php
@@ -58,6 +58,21 @@ class ThrottleMiddlewareTest extends TestCase
     }
 
     /**
+     * Test __construct with partial config provided
+     */
+    public function testConstructorWithPartialConfigProvided()
+    {
+        $middleware = new ThrottleMiddleware([
+            'response' => [
+                'body' => 'Rate limit exceeded',
+            ],
+        ]);
+        $result = $middleware->getConfig();
+
+        $this->assertTrue(array_key_exists('headers', $result['response']));
+    }
+
+    /**
      * Test __invoke
      */
     public function testInvoke()

--- a/tests/TestCase/Routing/Filter/ThrottleFilterTest.php
+++ b/tests/TestCase/Routing/Filter/ThrottleFilterTest.php
@@ -36,6 +36,9 @@ class ThrottleFilterTest extends TestCase
         }
     }
 
+    /**
+     * Test __construct
+     */
     public function testConstructor()
     {
         $filter = new ThrottleFilter();
@@ -53,6 +56,21 @@ class ThrottleFilterTest extends TestCase
             'reset' => 'X-RateLimit-Reset'
         ];
         $this->assertEquals($expectedHeaders, $result['headers']);
+    }
+
+    /**
+     * Test __construct with partial config provided
+     */
+    public function testConstructorWithPartialConfigProvided()
+    {
+        $filter = new ThrottleFilter([
+            'response' => [
+                'body' => 'Rate limit exceeded',
+            ],
+        ]);
+        $result = $filter->getConfig();
+
+        $this->assertTrue(array_key_exists('headers', $result['response']));
     }
 
     /**


### PR DESCRIPTION
is not working recursively (docs suggest it's okay to only specify array keys that should be overwritten for response)

e.g. only body