### PR TITLE
Allow for non-default, user defined, possibly dynamic request weight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /composer.lock
 /plugins
 /vendor
+/.idea

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "source": "https://github.com/usemuffin/throttle"
     },
     "require": {
-        "cakephp/cakephp": "^3.5"
+        "cakephp/cakephp": "^3.6"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",

--- a/src/Middleware/ThrottleMiddleware.php
+++ b/src/Middleware/ThrottleMiddleware.php
@@ -33,16 +33,16 @@ class ThrottleMiddleware
     /**
      * Called when the class is used as a function
      *
-     * @param \Cake\Http\ServerRequest $request Request object
-     * @param \Cake\Http\Response $response Response object
-     * @param callable $next Next class in middleware
+     * @param  \Cake\Http\ServerRequest $request  Request object
+     * @param  \Cake\Http\Response      $response Response object
+     * @param  callable                 $next     Next class in middleware
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function __invoke(ServerRequest $request, Response $response, callable $next)
     {
         $this->_setIdentifier($request);
         $this->_initCache();
-        $this->_count = $this->_touch();
+        $this->_count = $this->_touch($request);
 
         $config = $this->getConfig();
 

--- a/src/Middleware/ThrottleMiddleware.php
+++ b/src/Middleware/ThrottleMiddleware.php
@@ -8,7 +8,6 @@ use Muffin\Throttle\ThrottleTrait;
 
 class ThrottleMiddleware
 {
-
     use InstanceConfigTrait;
     use ThrottleTrait;
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Muffin\Throttle;
+
+use Cake\Core\BasePlugin;
+
+/**
+ * Plugin for Throttle
+ */
+class Plugin extends BasePlugin
+{
+
+}

--- a/src/Routing/Filter/ThrottleFilter.php
+++ b/src/Routing/Filter/ThrottleFilter.php
@@ -26,14 +26,14 @@ class ThrottleFilter extends DispatcherFilter
     /**
      * beforeDispatch.
      *
-     * @param \Cake\Event\Event $event Event instance
+     * @param  \Cake\Event\Event $event Event instance
      * @return mixed \Cake\Http\Response when limit is reached, void otherwise
      */
     public function beforeDispatch(Event $event)
     {
         $this->_setIdentifier($event->getData('request'));
         $this->_initCache();
-        $this->_count = $this->_touch();
+        $this->_count = $this->_touch($event->getData('request'));
 
         $config = $this->getConfig();
 
@@ -52,11 +52,13 @@ class ThrottleFilter extends DispatcherFilter
 
         // client has reached rate limit
         $event->stopPropagation();
-        $response = new Response([
+        $response = new Response(
+            [
             'body' => $message,
             'status' => 429,
             'type' => $config['response']['type']
-        ]);
+            ]
+        );
 
         if (is_array($config['response']['headers'])) {
             foreach ($config['response']['headers'] as $name => $value) {
@@ -70,7 +72,7 @@ class ThrottleFilter extends DispatcherFilter
     /**
      * afterDispatch.
      *
-     * @param \Cake\Event\Event $event Event instance
+     * @param  \Cake\Event\Event $event Event instance
      * @return \Cake\Http\Response Response instance
      */
     public function afterDispatch(Event $event)

--- a/src/Routing/Filter/ThrottleFilter.php
+++ b/src/Routing/Filter/ThrottleFilter.php
@@ -8,7 +8,6 @@ use Muffin\Throttle\ThrottleTrait;
 
 class ThrottleFilter extends DispatcherFilter
 {
-
     use ThrottleTrait;
 
     /**
@@ -56,7 +55,7 @@ class ThrottleFilter extends DispatcherFilter
             [
             'body' => $message,
             'status' => 429,
-            'type' => $config['response']['type']
+            'type' => $config['response']['type'],
             ]
         );
 

--- a/src/ThrottleTrait.php
+++ b/src/ThrottleTrait.php
@@ -2,6 +2,7 @@
 namespace Muffin\Throttle;
 
 use Cake\Cache\Cache;
+use Cake\Http\ServerRequest;
 
 trait ThrottleTrait
 {
@@ -138,7 +139,7 @@ trait ThrottleTrait
      * @param  \Psr\Http\Message\ServerRequestInterface|\Cake\Http\ServerRequest|null $request RequestInterface instance
      * @return mixed
      */
-    protected function _touch($request)
+    protected function _touch($request = null)
     {
         if (Cache::read($this->_identifier, static::$cacheConfig) === false) {
             Cache::write($this->_identifier, 0, static::$cacheConfig);
@@ -159,11 +160,16 @@ trait ThrottleTrait
      * @param  \Psr\Http\Message\ServerRequestInterface|\Cake\Http\ServerRequest|null $request RequestInterface instance
      * @return int
      */
-    protected function _getRequestWeight($request)
+    protected function _getRequestWeight($request = null)
     {
         $configWeight = $this->getConfig('weight');
 
-        if (empty($request) || (!is_int($configWeight) && !is_callable($configWeight))) {
+        if (
+            // classify simple issues with configuration
+            empty($request) || (!is_int($configWeight) && !is_callable($configWeight))
+            // classify request param contents
+            || !($request instanceof ServerRequest)
+        ) {
             // allow only integer or callable configurations
             return 1;
         }

--- a/src/ThrottleTrait.php
+++ b/src/ThrottleTrait.php
@@ -16,7 +16,7 @@ trait ThrottleTrait
         'response' => [
             'body' => 'Rate limit exceeded',
             'type' => 'text/html',
-            'headers' => []
+            'headers' => [],
         ],
         'interval' => '+1 minute',
         'limit' => 10,
@@ -25,7 +25,7 @@ trait ThrottleTrait
             'remaining' => 'X-RateLimit-Remaining',
             'reset' => 'X-RateLimit-Reset',
         ],
-        'weight' => 1
+        'weight' => 1,
     ];
 
     /**
@@ -96,7 +96,8 @@ trait ThrottleTrait
     {
         if (!Cache::getConfig(static::$cacheConfig)) {
             Cache::setConfig(
-                static::$cacheConfig, [
+                static::$cacheConfig,
+                [
                 'className' => $this->_getDefaultCacheConfigClassName(),
                 'prefix' => static::$cacheConfig . '_' . $this->_identifier,
                 'duration' => $this->getConfig('interval'),
@@ -165,7 +166,7 @@ trait ThrottleTrait
         $configWeight = $this->getConfig('weight');
 
         if (
-            // classify simple issues with configuration
+// classify simple issues with configuration
             empty($request) || (!is_int($configWeight) && !is_callable($configWeight))
             // classify request param contents
             || !($request instanceof ServerRequest)

--- a/tests/TestCase/Middleware/ThrottleMiddlewareTest.php
+++ b/tests/TestCase/Middleware/ThrottleMiddlewareTest.php
@@ -309,17 +309,17 @@ class ThrottleMiddlewareTest extends TestCase
         $invalidFunctions = [
             function () {
             },
-            function ($param1, $param2) {
+            function ($param1) {
             },
-            function () {
+            function ($param) {
 
                 return null;
             },
-            function () {
+            function ($param) {
 
                 return -1;
             },
-            function () {
+            function ($param) {
 
                 return "string";
             },
@@ -336,9 +336,7 @@ class ThrottleMiddlewareTest extends TestCase
 
         foreach ($invalidFunctions as $invalidFunction) {
             $middleware = new ThrottleMiddleware([
-                'weight' => function ($request) {
-                    return null;
-                },
+                'weight' => $invalidFunction,
             ]);
             $this->assertEquals(1, $reflection->method->invokeArgs($middleware, [new ServerRequest()]));
         }

--- a/tests/TestCase/Middleware/ThrottleMiddlewareTest.php
+++ b/tests/TestCase/Middleware/ThrottleMiddlewareTest.php
@@ -54,7 +54,7 @@ class ThrottleMiddlewareTest extends TestCase
         $expectedHeaders = [
             'limit' => 'X-RateLimit-Limit',
             'remaining' => 'X-RateLimit-Remaining',
-            'reset' => 'X-RateLimit-Reset'
+            'reset' => 'X-RateLimit-Reset',
         ];
         $this->assertEquals($expectedHeaders, $result['headers']);
     }
@@ -82,7 +82,7 @@ class ThrottleMiddlewareTest extends TestCase
         Cache::drop('throttle');
         Cache::setConfig('throttle', [
             'className' => $this->engineClass,
-            'prefix' => 'throttle_'
+            'prefix' => 'throttle_',
         ]);
 
         $middleware = new ThrottleMiddleware([
@@ -91,16 +91,16 @@ class ThrottleMiddlewareTest extends TestCase
                 'body' => 'Rate limit exceeded',
                 'type' => 'json',
                 'headers' => [
-                    'Custom-Header' => 'test/test'
-                ]
-            ]
+                    'Custom-Header' => 'test/test',
+                ],
+            ],
         ]);
 
         $response = new Response();
         $request = new ServerRequest([
             'environment' => [
-                'REMOTE_ADDR' => '192.168.1.33'
-            ]
+                'REMOTE_ADDR' => '192.168.1.33',
+            ],
         ]);
 
         $result = $middleware(
@@ -114,7 +114,7 @@ class ThrottleMiddlewareTest extends TestCase
         $expectedHeaders = [
             'X-RateLimit-Limit',
             'X-RateLimit-Remaining',
-            'X-RateLimit-Reset'
+            'X-RateLimit-Reset',
         ];
 
         $this->assertInstanceOf('Cake\Http\Response', $result);
@@ -131,7 +131,7 @@ class ThrottleMiddlewareTest extends TestCase
 
         $expectedHeaders = [
             'Custom-Header',
-            'Content-Type'
+            'Content-Type',
         ];
 
         $this->assertInstanceOf('Cake\Http\Response', $result);
@@ -153,7 +153,7 @@ class ThrottleMiddlewareTest extends TestCase
     {
         Cache::setConfig('file', [
             'className' => 'Cake\Cache\Engine\FileEngine',
-            'prefix' => 'throttle_'
+            'prefix' => 'throttle_',
         ]);
 
         $middleware = new ThrottleMiddleware();
@@ -178,7 +178,7 @@ class ThrottleMiddlewareTest extends TestCase
 
         // should throw an exception if identifier is not a callable
         $middleware = new ThrottleMiddleware([
-            'identifier' => 'non-callable-string'
+            'identifier' => 'non-callable-string',
         ]);
         $reflection = $this->getReflection($middleware, '_setIdentifier');
         $reflection->method->invokeArgs($middleware, [new ServerRequest()]);
@@ -191,7 +191,7 @@ class ThrottleMiddlewareTest extends TestCase
     {
         Cache::drop('default');
         Cache::setConfig('default', [
-            'className' => 'Cake\Cache\Engine\FileEngine'
+            'className' => 'Cake\Cache\Engine\FileEngine',
         ]);
 
         // test if new cache config is created if it does not exist
@@ -204,7 +204,7 @@ class ThrottleMiddlewareTest extends TestCase
         $expected = [
             'className' => 'File',
             'prefix' => 'throttle_',
-            'duration' => '+1 minute'
+            'duration' => '+1 minute',
         ];
 
         $this->assertEquals($expected, Cache::getConfig('throttle'));
@@ -225,7 +225,7 @@ class ThrottleMiddlewareTest extends TestCase
         // Make sure short cache engine names get resolved properly
         Cache::drop('default');
         Cache::setConfig('default', [
-            'className' => 'File'
+            'className' => 'File',
         ]);
 
         $expected = 'File';
@@ -235,7 +235,7 @@ class ThrottleMiddlewareTest extends TestCase
         // Make sure fully namespaced cache engine names get resolved properly
         Cache::drop('default');
         Cache::setConfig('default', [
-            'className' => 'Cake\Cache\Engine\FileEngine'
+            'className' => 'Cake\Cache\Engine\FileEngine',
         ]);
         $expected = 'File';
         $result = $reflection->method->invokeArgs($middleware, [new ServerRequest()]);
@@ -250,7 +250,7 @@ class ThrottleMiddlewareTest extends TestCase
         Cache::drop('throttle');
         Cache::setConfig('throttle', [
             'className' => $this->engineClass,
-            'prefix' => 'throttle_'
+            'prefix' => 'throttle_',
         ]);
 
         $middleware = new ThrottleMiddleware();
@@ -283,7 +283,7 @@ class ThrottleMiddlewareTest extends TestCase
             [''],
             [false],
             [true],
-            []
+            [],
         ];
 
         foreach ($incorrectParams as $incorrectParam) {
@@ -295,8 +295,9 @@ class ThrottleMiddlewareTest extends TestCase
                 if (!($request instanceof ServerRequest)) {
                     return 1;
                 }
+
                 return 5;
-            }
+            },
         ]);
 
         $this->assertEquals(1, $reflection->method->invokeArgs($middleware, []));
@@ -306,25 +307,41 @@ class ThrottleMiddlewareTest extends TestCase
         $this->assertEquals(1, $reflection->method->invokeArgs($middleware, [new Response()]));
 
         $invalidFunctions = [
-            function (){ },
-            function ($param1, $param2) { },
-            function () { return null; },
-            function () { return -1; },
-            function () { return "string"; },
-            function ($param) { return $param; },
-            function ($param) { return $param->clientIp(); },
+            function () {
+            },
+            function ($param1, $param2) {
+            },
+            function () {
+
+                return null;
+            },
+            function () {
+
+                return -1;
+            },
+            function () {
+
+                return "string";
+            },
+            function ($param) {
+
+                return $param;
+            },
+            function ($param) {
+
+                return $param->clientIp();
+            },
             null,
         ];
 
-        foreach($invalidFunctions as $invalidFunction) {
+        foreach ($invalidFunctions as $invalidFunction) {
             $middleware = new ThrottleMiddleware([
                 'weight' => function ($request) {
                     return null;
-                }
+                },
             ]);
             $this->assertEquals(1, $reflection->method->invokeArgs($middleware, [new ServerRequest()]));
         }
-
     }
 
     /**
@@ -355,7 +372,7 @@ class ThrottleMiddlewareTest extends TestCase
     {
         // test disabled headers, should return null
         $middleware = new ThrottleMiddleware([
-            'headers' => false
+            'headers' => false,
         ]);
         $reflection = $this->getReflection($middleware, '_setHeaders');
         $result = $reflection->method->invokeArgs($middleware, [new Response()]);

--- a/tests/TestCase/Routing/Filter/ThrottleFilterTest.php
+++ b/tests/TestCase/Routing/Filter/ThrottleFilterTest.php
@@ -53,7 +53,7 @@ class ThrottleFilterTest extends TestCase
         $expectedHeaders = [
             'limit' => 'X-RateLimit-Limit',
             'remaining' => 'X-RateLimit-Remaining',
-            'reset' => 'X-RateLimit-Reset'
+            'reset' => 'X-RateLimit-Reset',
         ];
         $this->assertEquals($expectedHeaders, $result['headers']);
     }
@@ -81,7 +81,7 @@ class ThrottleFilterTest extends TestCase
         Cache::drop('throttle');
         Cache::setConfig('throttle', [
             'className' => $this->engineClass,
-            'prefix' => 'throttle_'
+            'prefix' => 'throttle_',
         ]);
 
         $filter = new ThrottleFilter([
@@ -90,15 +90,15 @@ class ThrottleFilterTest extends TestCase
                 'body' => 'Rate limit exceeded',
                 'type' => 'json',
                 'headers' => [
-                    'Custom-Header' => 'test/test'
-                ]
-            ]
+                    'Custom-Header' => 'test/test',
+                ],
+            ],
         ]);
         $response = new Response();
         $request = new ServerRequest([
             'environment' => [
-                'REMOTE_ADDR' => '192.168.1.2'
-            ]
+                'REMOTE_ADDR' => '192.168.1.2',
+            ],
         ]);
 
         $event = new Event('Dispatcher.beforeDispatch', $this, compact('request', 'response'));
@@ -117,7 +117,7 @@ class ThrottleFilterTest extends TestCase
 
         $expectedHeaders = [
             'Content-Type',
-            'Custom-Header'
+            'Custom-Header',
         ];
         $this->assertEquals($expectedHeaders, array_keys($result->getHeaders()));
     }
@@ -130,17 +130,17 @@ class ThrottleFilterTest extends TestCase
         Cache::drop('throttle');
         Cache::setConfig('throttle', [
             'className' => $this->engineClass,
-            'prefix' => 'throttle_'
+            'prefix' => 'throttle_',
         ]);
 
         $filter = new ThrottleFilter([
-            'limit' => 1
+            'limit' => 1,
         ]);
         $response = new Response();
         $request = new ServerRequest([
             'environment' => [
-                'HTTP_CLIENT_IP' => '192.168.1.2'
-            ]
+                'HTTP_CLIENT_IP' => '192.168.1.2',
+            ],
         ]);
 
         $event = new Event('Dispatcher.beforeDispatch', $this, compact('request', 'response'));
@@ -157,7 +157,7 @@ class ThrottleFilterTest extends TestCase
     {
         Cache::setConfig('file', [
             'className' => 'Cake\Cache\Engine\FileEngine',
-            'prefix' => 'throttle_'
+            'prefix' => 'throttle_',
         ]);
 
         $filter = new ThrottleFilter();
@@ -182,7 +182,7 @@ class ThrottleFilterTest extends TestCase
 
         // should throw an exception if identifier is not a callable
         $filter = new ThrottleFilter([
-            'identifier' => 'non-callable-string'
+            'identifier' => 'non-callable-string',
         ]);
         $reflection = $this->getReflection($filter, '_setIdentifier');
         $reflection->method->invokeArgs($filter, [new ServerRequest()]);
@@ -195,7 +195,7 @@ class ThrottleFilterTest extends TestCase
     {
         Cache::drop('default');
         Cache::setConfig('default', [
-            'className' => 'Cake\Cache\Engine\FileEngine'
+            'className' => 'Cake\Cache\Engine\FileEngine',
         ]);
 
         // test if new cache config is created if it does not exist
@@ -206,7 +206,7 @@ class ThrottleFilterTest extends TestCase
         $expected = [
             'className' => 'File',
             'prefix' => 'throttle_',
-            'duration' => '+1 minute'
+            'duration' => '+1 minute',
         ];
         $this->assertEquals($expected, Cache::getConfig('throttle'));
 
@@ -226,7 +226,7 @@ class ThrottleFilterTest extends TestCase
         // Make sure short cache engine names get resolved properly
         Cache::drop('default');
         Cache::setConfig('default', [
-            'className' => 'File'
+            'className' => 'File',
         ]);
         $expected = 'File';
         $result = $reflection->method->invokeArgs($filter, [new ServerRequest()]);
@@ -235,7 +235,7 @@ class ThrottleFilterTest extends TestCase
         // Make sure fully namespaced cache engine names get resolved properly
         Cache::drop('default');
         Cache::setConfig('default', [
-            'className' => 'Cake\Cache\Engine\FileEngine'
+            'className' => 'Cake\Cache\Engine\FileEngine',
         ]);
         $expected = 'File';
         $result = $reflection->method->invokeArgs($filter, [new ServerRequest()]);
@@ -250,7 +250,7 @@ class ThrottleFilterTest extends TestCase
         Cache::drop('throttle');
         Cache::setConfig('throttle', [
             'className' => $this->engineClass,
-            'prefix' => 'throttle_'
+            'prefix' => 'throttle_',
         ]);
 
         $filter = new ThrottleFilter();
@@ -300,7 +300,7 @@ class ThrottleFilterTest extends TestCase
     {
         // test disabled headers, should return null
         $filter = new ThrottleFilter([
-            'headers' => false
+            'headers' => false,
         ]);
         $reflection = $this->getReflection($filter, '_setHeaders');
         $result = $reflection->method->invokeArgs($filter, [new Response()]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,4 +29,5 @@ if (file_exists($root . '/config/bootstrap.php')) {
 
 require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
 
-\Cake\Core\Plugin::load('Muffin/Throttle', ['path' => dirname(dirname(__FILE__)) . DS]);
+Cake\Core\Plugin::getCollection()->add(new \Muffin\Throttle\Plugin());
+//\Cake\Core\Plugin::load('Muffin/Throttle', ['path' => dirname(dirname(__FILE__)) . DS]);


### PR DESCRIPTION
This should also fix the #20 discussion

This allows for the request weight to be dynamically calculated by user (by default it's simple int config, but allowing callable that returns integer)

I've yet to create some docs about it, but it should allow you to, for example:
  - different request weight depending on URL (ie. password recovery, login form or other usually brute-forced methods to reach rate limit sooner than the others)
  - Allowing some requests (URLs) to not be rated within limits, if the callable returns 0
  - Allowing different limits, rates, ... for authenticated and not authenticated users

I've hopefully fixed all CI tests in expected manner, PR commits should probably get squashed on review/accept

Since I've changed bootstrap of tests to use PluginCollection, I needed to raise the cakephp min. version from 3.5 to 3.6, but that should be ok, given how long the 3.5 is unsupported, which is 3.6 as well, but that is not important