### PR TITLE
Allow for non-default, user defined, possibly dynamic request weight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /plugins
 /vendor
 .phpunit.result.cache
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /plugins
 /vendor
 .phpunit.result.cache
-/.idea

--- a/src/Middleware/ThrottleMiddleware.php
+++ b/src/Middleware/ThrottleMiddleware.php
@@ -216,7 +216,9 @@ class ThrottleMiddleware implements MiddlewareInterface
         }
 
         if (!is_int($configWeight) || (is_int($configWeight) && $configWeight < 0)) {
-            throw new InvalidArgumentException('Throttle requestWeight option, or number returned by callback, must be >= 0');
+            throw new InvalidArgumentException(
+                'Throttle requestWeight option, or number returned by callback, must be >= 0'
+            );
         }
 
         return $configWeight;

--- a/src/Middleware/ThrottleMiddleware.php
+++ b/src/Middleware/ThrottleMiddleware.php
@@ -35,7 +35,7 @@ class ThrottleMiddleware implements MiddlewareInterface
             'remaining' => 'X-RateLimit-Remaining',
             'reset' => 'X-RateLimit-Reset',
         ],
-        'request_weight' => 1,
+        'requestWeight' => 1,
     ];
 
     /**
@@ -209,17 +209,17 @@ class ThrottleMiddleware implements MiddlewareInterface
      */
     protected function _getRequestWeight(ServerRequestInterface $request): int
     {
-        $configWeight = $this->getConfig('request_weight');
-
-        if (!is_int($configWeight) && !is_callable($configWeight)) {
-            return 1;
-        }
+        $configWeight = $this->getConfig('requestWeight');
 
         if (is_callable($configWeight)) {
             $configWeight = $configWeight($request);
         }
 
-        return is_int($configWeight) && $configWeight >= 0 ? $configWeight : 1;
+        if (!is_int($configWeight) || (is_int($configWeight) && $configWeight < 0)) {
+            throw new InvalidArgumentException('Throttle requestWeight option, or number returned by callback, must be >= 0');
+        }
+
+        return $configWeight;
     }
 
     /**

--- a/src/Middleware/ThrottleMiddleware.php
+++ b/src/Middleware/ThrottleMiddleware.php
@@ -211,11 +211,11 @@ class ThrottleMiddleware implements MiddlewareInterface
     {
         $configWeight = $this->getConfig('requestWeight');
 
-        if (is_callable($configWeight)) {
+        if ($configWeight instanceof Closure) {
             $configWeight = $configWeight($request);
         }
 
-        if (!is_int($configWeight) || (is_int($configWeight) && $configWeight < 0)) {
+        if (!is_int($configWeight) || $configWeight < 0) {
             throw new InvalidArgumentException(
                 'Throttle requestWeight option, or number returned by callback, must be >= 0'
             );

--- a/tests/TestCase/Middleware/ThrottleMiddlewareTest.php
+++ b/tests/TestCase/Middleware/ThrottleMiddlewareTest.php
@@ -8,6 +8,7 @@ use Cake\Cache\Engine\ApcuEngine;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use Muffin\Throttle\Middleware\ThrottleMiddleware;
 use Psr\Http\Message\ServerRequestInterface;
 use stdClass;
@@ -321,7 +322,7 @@ class ThrottleMiddlewareTest extends TestCase
     public function testConfigurableRequestWeight(): void
     {
         $middleware = new ThrottleMiddleware([
-            'request_weight' => function (ServerRequestInterface $request) {
+            'requestWeight' => function (ServerRequestInterface $request) {
                 if (!($request instanceof ServerRequest)) {
                     return 1;
                 }
@@ -363,10 +364,11 @@ class ThrottleMiddlewareTest extends TestCase
 
         foreach ($invalidFunctions as $invalidFunction) {
             $middleware = new ThrottleMiddleware([
-                'request_weight' => $invalidFunction,
+                'requestWeight' => $invalidFunction,
             ]);
             $reflection = $this->getReflection($middleware, '_getRequestWeight');
-            $this->assertEquals(1, $reflection->method->invokeArgs($middleware, [new ServerRequest()]));
+            $this->expectException(InvalidArgumentException::class);
+            $reflection->method->invokeArgs($middleware, [new ServerRequest()]);
         }
 
         $invalidConfigurations = [
@@ -377,10 +379,11 @@ class ThrottleMiddlewareTest extends TestCase
 
         foreach ($invalidConfigurations as $invalidConfiguration) {
             $middleware = new ThrottleMiddleware([
-                'request_weight' => $invalidConfiguration,
+                'requestWeight' => $invalidConfiguration,
             ]);
             $reflection = $this->getReflection($middleware, '_getRequestWeight');
-            $this->assertEquals(1, $reflection->method->invokeArgs($middleware, [new ServerRequest()]));
+            $this->expectException(InvalidArgumentException::class);
+            $reflection->method->invokeArgs($middleware, [new ServerRequest()]);
         }
     }
 


### PR DESCRIPTION
This should also fix the #20 discussion

This allows for the request weight to be dynamically calculated by user (by default it's simple int config, but allowing callable that returns integer >= 0)

I've yet to create some docs about it, but it should allow you to, for example:

- different request weight depending on URL (ie. password recovery, login form or other usually brute-forced methods to reach rate limit sooner than the others)
- Allowing some requests (URLs) to not be rated within limits, if the callable returns 0
- Allowing different limits, rates, ... for authenticated and not authenticated users