### PR TITLE
Throtttle.beforeCacheSet event made useful and added documentation

### DIFF
--- a/src/Middleware/ThrottleMiddleware.php
+++ b/src/Middleware/ThrottleMiddleware.php
@@ -186,7 +186,7 @@ class ThrottleMiddleware implements MiddlewareInterface, EventDispatcherInterfac
         $event = $this->dispatchEvent(self::EVENT_BEFORE_CACHE_SET, [
             'rateLimit' => $rateLimit,
             'ttl' => $ttl,
-            'throttleInfo' => $throttle,
+            'throttleInfo' => clone $throttle,
         ]);
 
         $cacheEngine->set($key, $event->getData()['rateLimit'], $event->getData()['ttl']);

--- a/src/Middleware/ThrottleMiddleware.php
+++ b/src/Middleware/ThrottleMiddleware.php
@@ -186,6 +186,7 @@ class ThrottleMiddleware implements MiddlewareInterface, EventDispatcherInterfac
         $event = $this->dispatchEvent(self::EVENT_BEFORE_CACHE_SET, [
             'rateLimit' => $rateLimit,
             'ttl' => $ttl,
+            'throttleInfo' => $throttle,
         ]);
 
         $cacheEngine->set($key, $event->getData()['rateLimit'], $event->getData()['ttl']);


### PR DESCRIPTION
- Event beforeCacheSet provided rateLimit and ttl, but no connection to existing ThrottleInfo, so the event was not usable really
- Added documentation for this event and fixed previously wrong variables and class names

as mentioned in docs, modifying throttleInfo in this event has no effect, but modifying rateLimit and ttl does, as intended
providing the throttleInfo is useful for consistency with `Throttle.getThrottleInfo`, so it can be observed if limits are applied as expected